### PR TITLE
F1884 automated config

### DIFF
--- a/.nullstone/module.yml
+++ b/.nullstone/module.yml
@@ -1,7 +1,7 @@
 org_name: nullstone
 name: aws-appsync-api-access
 friendly_name: AppSync Graphql API Access
-description: Capability to provide access from a static site to a graphql api hosted on AWS AppSync
+description: Capability that injects information about an AWS AppSync Graphql API into an application
 category: capability
 subcategory: ingress
 provider_types:
@@ -10,5 +10,6 @@ platform: graphql
 subplatform: appsync
 type: ""
 appCategories:
-    - static-site
+    - container
+    - serverless
 is_public: true

--- a/appsync_api.tf
+++ b/appsync_api.tf
@@ -4,5 +4,6 @@ data "ns_connection" "api" {
 }
 
 locals {
-  api_endpoint = data.ns_connection.api.outputs.api_endpoint
+  graphql_api_id = data.ns_connection.api.outputs.graphql_api_id
+  api_endpoint   = data.ns_connection.api.outputs.api_endpoint
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,10 @@
 output "env" {
   value = [
     {
+      name  = "GRAPHQL_API_ID"
+      value = local.graphql_api_id
+    },
+    {
       name  = "GRAPHQL_ENDPOINT"
       value = local.api_endpoint
     },


### PR DESCRIPTION
Updated this module so that it can be used by "migration" style apps. It is now configured to be used with container or serverless apps and will inject what is needed to manage the appsync api.